### PR TITLE
rolex: Add omx in manifest

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -147,6 +147,19 @@ included.
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.media.omx</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IOmx</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IOmxStore</name>
+            <instance>default</instance>
+        </interface>
+    </hal> 
+    <hal format="hidl">
         <name>android.hardware.memtrack</name>
         <transport arch="32+64">passthrough</transport>
         <version>1.0</version>


### PR DESCRIPTION
This fixes  getTransport: Cannot find entry android.hardware.media.omx@1.0::IOmx/default in either framework or device manifest.