### PR TITLE
rolex: init: Add a missing header

### DIFF
--- a/init/init_rolex.cpp
+++ b/init/init_rolex.cpp
@@ -35,6 +35,7 @@
 #include <android-base/properties.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
+#include <android-base/file.h>
 
 #include "vendor_init.h"
 #include "property_service.h"


### PR DESCRIPTION
* Thanks to @The_Tweaker on Telegram for bringing this mistake to my attention
* Fixes these errors:
```
device/xiaomi/rolex/init/init_rolex.cpp:44:22: error: no member named 'ReadFileToString' in namespace 'android::base'
using android::base::ReadFileToString;
      ~~~~~~~~~~~~~~~^
device/xiaomi/rolex/init/init_rolex.cpp:54:9: error: use of undeclared identifier 'ReadFileToString'
    if (ReadFileToString(boot_reason_file, &boot_reason)
        ^
device/xiaomi/rolex/init/init_rolex.cpp:55:16: error: use of undeclared identifier 'ReadFileToString'
            && ReadFileToString(power_off_alarm_file, &power_off_alarm)) {
               ^
```